### PR TITLE
Further accelerate xor when byte arrays happen to be aligned

### DIFF
--- a/cbits/simd.h
+++ b/cbits/simd.h
@@ -1,3 +1,5 @@
+#include "Rts.h"
+
 #include <unistd.h>
 #include <stdint.h>
 
@@ -41,7 +43,7 @@ void avx2_or_bits(
     uint8_t *source_b);
 
 void avx2_xor_bits(
-    uint8_t *target,
-    size_t target_length,
-    uint8_t *source_a,
-    uint8_t *source_b);
+    uint8_t* restrict target,
+    HsInt target_length,
+    uint8_t* restrict source_a,
+    uint8_t* restrict source_b);

--- a/src/Simd.hs
+++ b/src/Simd.hs
@@ -9,6 +9,7 @@
 module Simd
   ( Simd.xor
   , Simd.xorMutable
+  , Simd.xorInto
   , Simd.or
   , Simd.orMutable
   , Simd.and
@@ -54,6 +55,15 @@ xorMutable :: ()
   -> ST s (MutableByteArray s)
 xorMutable = binop "xorMutable" avx2_xor_bits
 {-# inline xorMutable #-}
+
+xorInto :: ()
+  => MutableByteArray s
+  -> ByteArray
+  -> ByteArray
+  -> Int
+  -> ST s ()
+xorInto (MutableByteArray dst) (ByteArray a) (ByteArray b) (I# len) =
+  avx2_or_bits dst len a b
 
 or :: ()
   => ByteArray

--- a/src/Simd.hs
+++ b/src/Simd.hs
@@ -63,7 +63,7 @@ xorInto :: ()
   -> Int
   -> ST s ()
 xorInto (MutableByteArray dst) (ByteArray a) (ByteArray b) (I# len) =
-  avx2_or_bits dst len a b
+  avx2_xor_bits dst len a b
 
 or :: ()
   => ByteArray


### PR DESCRIPTION
Commit message: Further accelerate xor when byte arrays happen to be aligned appropriately. Use HsInt where appropriate. Benchmark the results of xor on aligned arrays, demonstrating a 27% speedup over unaligned arrays.

I have two possibilities in mind for how this could be useful:

1. User is able to exercise sufficient control over creation of all involved byte arrays.
2. With additional work, it should be possible to add a runtime flag to GHC that forces N-byte alignment, for a configurable N, of large bytearrays (the ones over 3KB that the runtime decides to pin without the user requesting it). Ordinarily, such a flag would be bad. However, if an application author knew that there were a bunch of operations that were accelerated when bytearrays were all N-byte aligned, using the flag would let the user speed up all of their boolean logic operations on byte arrays **without** having to think about the provenance of the arrays. Then the user would only have to make sure that they operated on sufficiently large arrays (over 3KB), but that much easier to do.